### PR TITLE
Add React Tailwind prototype page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,32 @@
 # CryptoExQuoteCalc
-A small tool for friends to practice crypto-to-fiat conversion, helping learn value and pricing through simple quote simulations.
+
+**A lightweight OTC calculator for fast and transparent crypto-to-fiat quotations.**
+
+## 📌 Overview
+CryptoExQuoteCalc is a simple web-based tool designed for OTC (over-the-counter) crypto traders.  
+It helps you generate **buy and sell quotations** in seconds, showing **market price, quoted price, and profit margins** clearly.
+
+## ✨ Features
+- Input ETH/USD and USD/CNY exchange rates
+- Configure **gas costs** and **premium %** (separately for buy/sell)
+- Calculate:
+  - Market price (RMB/ETH)
+  - Buy price (RMB you pay to acquire ETH)
+  - Sell price (RMB you receive when selling ETH)
+  - Profit difference
+- Convert ETH ↔ RMB based on quotation
+- One-click copy to share quotation
+
+## 🛠️ Tech Stack
+- React + Tailwind CSS
+- Pure front-end calculation (no backend needed)
+- Deployable on Vercel / GitHub Pages
+
+## 🚀 Roadmap
+- [ ] Add USDT/USDC support
+- [ ] Save historical quotations
+- [ ] Auto-fetch live exchange rates via Binance/OKX API
+- [ ] Gas cost presets for Ethereum mainnet / L2 chains
+
+## 📄 License
+MIT License

--- a/index.html
+++ b/index.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>CryptoExQuoteCalc</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+</head>
+<body class="p-4">
+  <div id="root"></div>
+  <script type="text/babel">
+    const { useState } = React;
+
+    function App() {
+      const [ethUsd, setEthUsd] = useState(3000);
+      const [usdCny, setUsdCny] = useState(7);
+      const [gas, setGas] = useState(20);
+      const [buyPremium, setBuyPremium] = useState(2);
+      const [sellPremium, setSellPremium] = useState(2);
+      const [ethAmount, setEthAmount] = useState(1);
+      const [rmbAmount, setRmbAmount] = useState('');
+
+      const marketPrice = ethUsd * usdCny;
+      const buyPrice = marketPrice * (1 + buyPremium / 100) + gas;
+      const sellPrice = marketPrice * (1 - sellPremium / 100) - gas;
+      const profitBuy = marketPrice * buyPremium / 100;
+      const profitSell = marketPrice * sellPremium / 100;
+
+      const handleEthChange = (e) => {
+        setEthAmount(e.target.value);
+        setRmbAmount('');
+      };
+
+      const handleRmbChange = (e) => {
+        setRmbAmount(e.target.value);
+        setEthAmount('');
+      };
+
+      const ethTotal = rmbAmount !== '' ? (parseFloat(rmbAmount) || 0) / marketPrice : (parseFloat(ethAmount) || 0);
+      const rmbTotal = ethTotal * marketPrice;
+      const buyTotal = marketPrice * ethTotal * (1 + buyPremium / 100) + gas;
+      const sellTotal = marketPrice * ethTotal * (1 - sellPremium / 100) - gas;
+      const profitBuyTotal = buyTotal - (marketPrice * ethTotal + gas);
+      const profitSellTotal = (marketPrice * ethTotal - gas) - sellTotal;
+
+      const copyText = (type) => {
+        const text = type === 'buy'
+          ? `Buy ${ethTotal.toFixed(4)} ETH @ ${buyPrice.toFixed(2)} RMB (total ${buyTotal.toFixed(2)} RMB)`
+          : `Sell ${ethTotal.toFixed(4)} ETH @ ${sellPrice.toFixed(2)} RMB (total ${sellTotal.toFixed(2)} RMB)`;
+        navigator.clipboard.writeText(text);
+      };
+
+      const reset = () => {
+        setEthUsd(3000);
+        setUsdCny(7);
+        setGas(20);
+        setBuyPremium(2);
+        setSellPremium(2);
+        setEthAmount(1);
+        setRmbAmount('');
+      };
+
+      return (
+        <div className="max-w-xl mx-auto space-y-4">
+          <h1 className="text-2xl font-bold">CryptoExQuoteCalc</h1>
+          <div className="grid grid-cols-2 gap-4">
+            <label className="flex flex-col">ETH/USD
+              <input type="number" className="border p-1" value={ethUsd} onChange={e => setEthUsd(parseFloat(e.target.value) || 0)} />
+            </label>
+            <label className="flex flex-col">USD/CNY
+              <input type="number" className="border p-1" value={usdCny} onChange={e => setUsdCny(parseFloat(e.target.value) || 0)} />
+            </label>
+            <label className="flex flex-col">Gas Cost (RMB)
+              <input type="number" className="border p-1" value={gas} onChange={e => setGas(parseFloat(e.target.value) || 0)} />
+            </label>
+            <label className="flex flex-col">Buy Premium %
+              <input type="number" className="border p-1" value={buyPremium} onChange={e => setBuyPremium(parseFloat(e.target.value) || 0)} />
+            </label>
+            <label className="flex flex-col">Sell Premium %
+              <input type="number" className="border p-1" value={sellPremium} onChange={e => setSellPremium(parseFloat(e.target.value) || 0)} />
+            </label>
+            <label className="flex flex-col">Amount ETH
+              <input type="number" className="border p-1" value={ethAmount} onChange={handleEthChange} placeholder="1" />
+            </label>
+            <label className="flex flex-col">Amount RMB
+              <input type="number" className="border p-1" value={rmbAmount} onChange={handleRmbChange} placeholder="auto" />
+            </label>
+          </div>
+
+          <div className="border p-4 space-y-2">
+            <div>Market Price: {marketPrice.toFixed(2)} RMB / ETH</div>
+            <div>Buy Price: {buyPrice.toFixed(2)} RMB / ETH (Profit {profitBuy.toFixed(2)})</div>
+            <div>Sell Price: {sellPrice.toFixed(2)} RMB / ETH (Profit {profitSell.toFixed(2)})</div>
+          </div>
+
+          <div className="border p-4 space-y-2">
+            <div>Market Total: {rmbTotal.toFixed(2)} RMB</div>
+            <div>Buy Total: {buyTotal.toFixed(2)} RMB (Profit {profitBuyTotal.toFixed(2)})</div>
+            <div>Sell Total: {sellTotal.toFixed(2)} RMB (Profit {profitSellTotal.toFixed(2)})</div>
+          </div>
+
+          <div className="flex gap-2">
+            <button className="px-2 py-1 bg-blue-500 text-white" onClick={() => copyText('buy')}>Copy Buy</button>
+            <button className="px-2 py-1 bg-green-500 text-white" onClick={() => copyText('sell')}>Copy Sell</button>
+            <button className="px-2 py-1 bg-gray-300" onClick={reset}>Reset</button>
+          </div>
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cryptoexquotecalc",
+  "version": "1.0.0",
+  "description": "A small tool for friends to practice crypto-to-fiat conversion, helping learn value and pricing through simple quote simulations.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"No tests\""
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}


### PR DESCRIPTION
## Summary
- replace README with project overview and roadmap
- add React+Tailwind prototype page for OTC quotes
- provide minimal package with test placeholder

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba916faf34832baffdcfb476148ab8