### PR TITLE
feat: interactive quote calc with formulas

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,12 @@ CryptoExQuoteCalc is a simple web-based tool designed for OTC (over-the-counter)
 It helps you generate **buy and sell quotations** in seconds, showing **market price, quoted price, and profit margins** clearly.
 
 ## ✨ Features
-- Input ETH/USD and USD/CNY exchange rates
-- Configure **gas costs** and **premium %** (separately for buy/sell)
-- Calculate:
-  - Market price (RMB/ETH)
-  - Buy price (RMB you pay to acquire ETH)
-  - Sell price (RMB you receive when selling ETH)
-  - Profit difference
-- Convert ETH ↔ RMB based on quotation
+- Bilingual interface (English / 中文)
+- Input ETHUSD price and fiat rate (CNY/USD)
+- Configure **premium %** and **fiat fee** (blank inputs default to 0)
+- Interactive conversion between crypto and fiat — typing in one field auto-calculates the other
+- Detailed calculation steps rendered with LaTeX, comparing market vs. premium totals (incl. fee)
+- Responsive layout using Flexbox + Grid with contextual hints beside each field
 - One-click copy to share quotation
 
 ## 🛠️ Tech Stack

--- a/index.html
+++ b/index.html
@@ -7,104 +7,211 @@
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script crossorigin src="https://unpkg.com/babel-standalone@6/babel.min.js"></script>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" />
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
 </head>
 <body class="p-4">
   <div id="root"></div>
   <script type="text/babel">
-    const { useState } = React;
+    const { useState, useEffect } = React;
+
+    const Formula = ({ formula }) => (
+      <span dangerouslySetInnerHTML={{ __html: katex.renderToString(formula) }} />
+    );
 
     function App() {
-      const [ethUsd, setEthUsd] = useState(3000);
-      const [usdCny, setUsdCny] = useState(7);
-      const [gas, setGas] = useState(20);
-      const [buyPremium, setBuyPremium] = useState(2);
-      const [sellPremium, setSellPremium] = useState(2);
-      const [ethAmount, setEthAmount] = useState(1);
-      const [rmbAmount, setRmbAmount] = useState('');
-
-      const marketPrice = ethUsd * usdCny;
-      const buyPrice = marketPrice * (1 + buyPremium / 100) + gas;
-      const sellPrice = marketPrice * (1 - sellPremium / 100) - gas;
-      const profitBuy = marketPrice * buyPremium / 100;
-      const profitSell = marketPrice * sellPremium / 100;
-
-      const handleEthChange = (e) => {
-        setEthAmount(e.target.value);
-        setRmbAmount('');
+      const translations = {
+        en: {
+          toggle: '中文',
+          ethUsd: 'ETHUSD Price',
+          usdCny: 'Fiat Rate (CNY/USD)',
+          fee: 'Fiat Fee',
+          premium: 'Premium %',
+          crypto: 'Crypto (ETH)',
+          fiat: 'Fiat (CNY)',
+          marketPrice: 'Market Price',
+          priceWithPremium: 'Price With Premium',
+          premiumDiff: 'Premium Difference',
+          marketTotal: 'Total w/o Premium + Fee',
+          premiumTotal: 'Total w/ Premium + Fee',
+          ethUsdHint: 'DEX/CEX market',
+          usdCnyHint: '1 USD equals CNY',
+          feeHint: 'Handling fee in CNY',
+          premiumHint: '0-100%',
+          cryptoHint: 'Input or auto calc',
+          fiatHint: 'Input or auto calc',
+          copy: 'Copy',
+          reset: 'Reset'
+        },
+        zh: {
+          toggle: 'EN',
+          ethUsd: 'ETHUSD 价格',
+          usdCny: '法币汇率 (CNY/USD)',
+          fee: '法币手续费',
+          premium: '溢价 %',
+          crypto: '加密数量 (ETH)',
+          fiat: '法币数量 (CNY)',
+          marketPrice: '市场价',
+          priceWithPremium: '溢价后价格',
+          premiumDiff: '溢价差额',
+          marketTotal: '总价（无溢价+手续费）',
+          premiumTotal: '总价（含溢价+手续费）',
+          ethUsdHint: '与DEX/CEX行情一致',
+          usdCnyHint: '1美元兑换多少人民币',
+          feeHint: '以人民币计的手续费',
+          premiumHint: '范围0-100%',
+          cryptoHint: '输入或自动计算',
+          fiatHint: '输入或自动计算',
+          copy: '复制',
+          reset: '重置'
+        }
       };
 
-      const handleRmbChange = (e) => {
-        setRmbAmount(e.target.value);
-        setEthAmount('');
+      const [lang, setLang] = useState('en');
+      const t = translations[lang];
+
+      const [ethUsd, setEthUsd] = useState('3000');
+      const [usdCny, setUsdCny] = useState('7.10000');
+      const [fee, setFee] = useState('20');
+      const [premium, setPremium] = useState('3.275');
+      const [ethAmount, setEthAmount] = useState('0');
+      const [cnyAmount, setCnyAmount] = useState('0');
+      const [lastChanged, setLastChanged] = useState('eth');
+
+      const ethUsdNum = parseFloat(ethUsd) || 0;
+      const usdCnyNum = parseFloat(usdCny) || 0;
+      const feeNum = parseFloat(fee) || 0;
+      const premiumNum = parseFloat(premium) || 0;
+
+      const marketPrice = ethUsdNum * usdCnyNum;
+      const priceWithPremium = marketPrice * (1 + premiumNum / 100);
+
+      const updateFromEth = (value) => {
+        setLastChanged('eth');
+        setEthAmount(value);
+        const num = parseFloat(value);
+        if (!isNaN(num)) {
+          setCnyAmount((num * priceWithPremium + feeNum).toFixed(2));
+        } else {
+          setCnyAmount('');
+        }
       };
 
-      const ethTotal = rmbAmount !== '' ? (parseFloat(rmbAmount) || 0) / marketPrice : (parseFloat(ethAmount) || 0);
-      const rmbTotal = ethTotal * marketPrice;
-      const buyTotal = marketPrice * ethTotal * (1 + buyPremium / 100) + gas;
-      const sellTotal = marketPrice * ethTotal * (1 - sellPremium / 100) - gas;
-      const profitBuyTotal = buyTotal - (marketPrice * ethTotal + gas);
-      const profitSellTotal = (marketPrice * ethTotal - gas) - sellTotal;
+      const updateFromCny = (value) => {
+        setLastChanged('cny');
+        setCnyAmount(value);
+        const num = parseFloat(value);
+        if (!isNaN(num)) {
+          setEthAmount(((num - feeNum) / priceWithPremium).toFixed(4));
+        } else {
+          setEthAmount('');
+        }
+      };
 
-      const copyText = (type) => {
-        const text = type === 'buy'
-          ? `Buy ${ethTotal.toFixed(4)} ETH @ ${buyPrice.toFixed(2)} RMB (total ${buyTotal.toFixed(2)} RMB)`
-          : `Sell ${ethTotal.toFixed(4)} ETH @ ${sellPrice.toFixed(2)} RMB (total ${sellTotal.toFixed(2)} RMB)`;
+      useEffect(() => {
+        if (lastChanged === 'eth') {
+          const num = parseFloat(ethAmount);
+          if (!isNaN(num)) {
+            setCnyAmount((num * priceWithPremium + feeNum).toFixed(2));
+          }
+        } else {
+          const num = parseFloat(cnyAmount);
+          if (!isNaN(num)) {
+            setEthAmount(((num - feeNum) / priceWithPremium).toFixed(4));
+          }
+        }
+      }, [ethUsd, usdCny, fee, premium]);
+
+      const clearZero = (setter) => (e) => {
+        if (e.target.value === '0') setter('');
+        else e.target.select();
+      };
+      const blurZero = (setter) => (e) => {
+        if (e.target.value === '') setter('0');
+      };
+
+      const ethNum = parseFloat(ethAmount) || 0;
+      const marketTotal = ethNum * marketPrice;
+      const marketTotalWithFee = marketTotal + feeNum;
+      const premiumTotal = ethNum * priceWithPremium;
+      const premiumTotalWithFee = premiumTotal + feeNum;
+      const premiumDiff = premiumTotalWithFee - marketTotalWithFee;
+
+      const copyQuote = () => {
+        const text = `${ethNum.toFixed(4)} ETH @ ${priceWithPremium.toFixed(5)} CNY (total ${premiumTotalWithFee.toFixed(2)} CNY)`;
         navigator.clipboard.writeText(text);
       };
 
       const reset = () => {
-        setEthUsd(3000);
-        setUsdCny(7);
-        setGas(20);
-        setBuyPremium(2);
-        setSellPremium(2);
-        setEthAmount(1);
-        setRmbAmount('');
+        setEthUsd('3000');
+        setUsdCny('7.10000');
+        setFee('20');
+        setPremium('3.275');
+        setEthAmount('0');
+        setCnyAmount('0');
+        setLastChanged('eth');
       };
 
       return (
-        <div className="max-w-xl mx-auto space-y-4">
-          <h1 className="text-2xl font-bold">CryptoExQuoteCalc</h1>
-          <div className="grid grid-cols-2 gap-4">
-            <label className="flex flex-col">ETH/USD
-              <input type="number" className="border p-1" value={ethUsd} onChange={e => setEthUsd(parseFloat(e.target.value) || 0)} />
+        <div className="max-w-xl mx-auto flex flex-col space-y-6 items-center">
+          <div className="w-full flex justify-between items-center">
+            <h1 className="text-2xl font-bold">CryptoExQuoteCalc</h1>
+            <button className="border px-2 py-1" onClick={() => setLang(lang === 'en' ? 'zh' : 'en')}>{t.toggle}</button>
+          </div>
+
+          <div className="w-full grid sm:grid-cols-2 gap-4">
+            <label className="flex flex-col">
+              {t.ethUsd}
+              <input type="number" className="border p-1" value={ethUsd} onChange={e => setEthUsd(e.target.value)} onFocus={clearZero(setEthUsd)} onBlur={blurZero(setEthUsd)} />
+              <span className="text-xs text-gray-500">{t.ethUsdHint}</span>
             </label>
-            <label className="flex flex-col">USD/CNY
-              <input type="number" className="border p-1" value={usdCny} onChange={e => setUsdCny(parseFloat(e.target.value) || 0)} />
-            </label>
-            <label className="flex flex-col">Gas Cost (RMB)
-              <input type="number" className="border p-1" value={gas} onChange={e => setGas(parseFloat(e.target.value) || 0)} />
-            </label>
-            <label className="flex flex-col">Buy Premium %
-              <input type="number" className="border p-1" value={buyPremium} onChange={e => setBuyPremium(parseFloat(e.target.value) || 0)} />
-            </label>
-            <label className="flex flex-col">Sell Premium %
-              <input type="number" className="border p-1" value={sellPremium} onChange={e => setSellPremium(parseFloat(e.target.value) || 0)} />
-            </label>
-            <label className="flex flex-col">Amount ETH
-              <input type="number" className="border p-1" value={ethAmount} onChange={handleEthChange} placeholder="1" />
-            </label>
-            <label className="flex flex-col">Amount RMB
-              <input type="number" className="border p-1" value={rmbAmount} onChange={handleRmbChange} placeholder="auto" />
+            <label className="flex flex-col">
+              {t.usdCny}
+              <input type="number" step="0.00001" className="border p-1" value={usdCny} onChange={e => setUsdCny(e.target.value)} onFocus={clearZero(setUsdCny)} onBlur={blurZero(setUsdCny)} />
+              <span className="text-xs text-gray-500">{t.usdCnyHint}</span>
             </label>
           </div>
 
-          <div className="border p-4 space-y-2">
-            <div>Market Price: {marketPrice.toFixed(2)} RMB / ETH</div>
-            <div>Buy Price: {buyPrice.toFixed(2)} RMB / ETH (Profit {profitBuy.toFixed(2)})</div>
-            <div>Sell Price: {sellPrice.toFixed(2)} RMB / ETH (Profit {profitSell.toFixed(2)})</div>
+          <div className="w-full grid sm:grid-cols-2 gap-4">
+            <label className="flex flex-col">
+              {t.premium}
+              <div className="flex border p-1 items-center">
+                <input type="number" min="0" max="100" step="0.001" className="flex-1 outline-none" value={premium} onChange={e => setPremium(e.target.value)} onFocus={clearZero(setPremium)} onBlur={blurZero(setPremium)} />
+                <span className="ml-1">%</span>
+              </div>
+              <span className="text-xs text-gray-500">{t.premiumHint}</span>
+            </label>
+            <label className="flex flex-col">
+              {t.fee}
+              <input type="number" className="border p-1" value={fee} onChange={e => setFee(e.target.value)} onFocus={clearZero(setFee)} onBlur={blurZero(setFee)} />
+              <span className="text-xs text-gray-500">{t.feeHint}</span>
+            </label>
           </div>
 
-          <div className="border p-4 space-y-2">
-            <div>Market Total: {rmbTotal.toFixed(2)} RMB</div>
-            <div>Buy Total: {buyTotal.toFixed(2)} RMB (Profit {profitBuyTotal.toFixed(2)})</div>
-            <div>Sell Total: {sellTotal.toFixed(2)} RMB (Profit {profitSellTotal.toFixed(2)})</div>
+          <div className="w-full grid sm:grid-cols-2 gap-4">
+            <label className="flex flex-col">
+              {t.crypto}
+              <input type="number" className="border p-1" value={ethAmount} onChange={e => updateFromEth(e.target.value)} onFocus={e => { if (e.target.value === '0') updateFromEth(''); else e.target.select(); }} onBlur={e => { if (e.target.value === '') updateFromEth('0'); }} />
+              <span className="text-xs text-gray-500">{t.cryptoHint}</span>
+            </label>
+            <label className="flex flex-col">
+              {t.fiat}
+              <input type="number" className="border p-1" value={cnyAmount} onChange={e => updateFromCny(e.target.value)} onFocus={e => { if (e.target.value === '0') updateFromCny(''); else e.target.select(); }} onBlur={e => { if (e.target.value === '') updateFromCny('0'); }} />
+              <span className="text-xs text-gray-500">{t.fiatHint}</span>
+            </label>
+          </div>
+
+          <div className="w-full border p-4 space-y-2" id="calc">
+            <div><Formula formula={`\\text{${t.marketPrice}} = ${ethUsdNum} \\times ${usdCnyNum} = ${marketPrice.toFixed(5)}`} /></div>
+            <div><Formula formula={`\\text{${t.priceWithPremium}} = ${marketPrice.toFixed(5)} \\times (1+${premiumNum}/100) = ${priceWithPremium.toFixed(5)}`} /></div>
+            <div><Formula formula={`\\text{${t.marketTotal}} = ${ethNum} \\times ${marketPrice.toFixed(5)} + ${feeNum} = ${marketTotalWithFee.toFixed(2)}`} /></div>
+            <div><Formula formula={`\\text{${t.premiumTotal}} = ${ethNum} \\times ${priceWithPremium.toFixed(5)} + ${feeNum} = ${premiumTotalWithFee.toFixed(2)}`} /></div>
+            <div><Formula formula={`\\text{${t.premiumDiff}} = ${premiumTotalWithFee.toFixed(2)} - ${marketTotalWithFee.toFixed(2)} = ${premiumDiff.toFixed(2)}`} /></div>
           </div>
 
           <div className="flex gap-2">
-            <button className="px-2 py-1 bg-blue-500 text-white" onClick={() => copyText('buy')}>Copy Buy</button>
-            <button className="px-2 py-1 bg-green-500 text-white" onClick={() => copyText('sell')}>Copy Sell</button>
-            <button className="px-2 py-1 bg-gray-300" onClick={reset}>Reset</button>
+            <button className="px-2 py-1 bg-blue-500 text-white" onClick={copyQuote}>{t.copy}</button>
+            <button className="px-2 py-1 bg-gray-300" onClick={reset}>{t.reset}</button>
           </div>
         </div>
       );


### PR DESCRIPTION
## Summary
- add flex+grid layout with bilingual hints
- support interactive crypto/fiat inputs with default-zero handling
- display step-by-step market vs premium calculations using LaTeX

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba9751e6a0832bb8a80162146229c9