### PR TITLE
fix: correct usd/CNY Chinese label

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,7 @@
         zh: {
           toggle: 'EN',
           ethUsd: 'ETHUSD 价格',
-          usdCny: '美元兑人民币 (CNY/USD)',
+          usdCny: '美元兑人民币 (USD/CNY)',
           fee: '手续费 (CNY)',
           premium: '溢价 %',
           ethAmount: '加密金额 (ETH)',


### PR DESCRIPTION
## Summary
- fix Chinese translation of USD/CNY rate to use `美元兑人民币 (USD/CNY)`

## Testing
- `npm test`
- `node -e "const fs=require('fs');const html=fs.readFileSync('index.html','utf8');const match=html.match(/const translations = ([\s\S]*?);\n\n/);const translations=eval('('+match[1]+')');let lang='en';console.log('en:',translations[lang].usdCny);lang='zh';console.log('zh:',translations[lang].usdCny);"`


------
https://chatgpt.com/codex/tasks/task_e_68baa82d19b8832bba9c157d21b099cc