### PR TITLE
Add calculation module with tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+coverage/

--- a/calc.js
+++ b/calc.js
@@ -1,0 +1,30 @@
+function calculateMarketPrice(ethUsd, usdCny) {
+  return ethUsd * usdCny;
+}
+
+function calculatePriceWithPremium(marketPrice, premiumPercent) {
+  return marketPrice * (1 + premiumPercent / 100);
+}
+
+function calculateTotals({ ethUsd, usdCny, premiumPercent, fee, ethAmount = 0, cnyAmount = '' }) {
+  const marketPrice = calculateMarketPrice(ethUsd, usdCny);
+  const priceWithPremium = calculatePriceWithPremium(marketPrice, premiumPercent);
+  const ethTotal = cnyAmount !== '' ? (parseFloat(cnyAmount) || 0) / marketPrice : (parseFloat(ethAmount) || 0);
+
+  const marketTotal = ethTotal * marketPrice;
+  const premiumTotal = ethTotal * priceWithPremium;
+
+  return {
+    marketPrice,
+    priceWithPremium,
+    marketTotalWithFee: marketTotal + fee,
+    premiumTotalWithFee: premiumTotal + fee,
+    premiumDiff: premiumTotal - marketTotal,
+  };
+}
+
+module.exports = {
+  calculateMarketPrice,
+  calculatePriceWithPremium,
+  calculateTotals,
+};

--- a/calc.test.js
+++ b/calc.test.js
@@ -1,0 +1,28 @@
+const { calculateMarketPrice, calculatePriceWithPremium, calculateTotals } = require('./calc');
+
+describe('calculation functions', () => {
+  test('calculateMarketPrice computes ETH to CNY price', () => {
+    expect(calculateMarketPrice(3000, 7)).toBe(21000);
+  });
+
+  test('calculatePriceWithPremium applies premium percentage', () => {
+    const marketPrice = 21000;
+    expect(calculatePriceWithPremium(marketPrice, 3.275)).toBeCloseTo(21687.75);
+  });
+
+  test('calculateTotals returns totals with fee and premium', () => {
+    const totals = calculateTotals({
+      ethUsd: 3000,
+      usdCny: 7,
+      premiumPercent: 3.275,
+      fee: 20,
+      ethAmount: 1,
+    });
+
+    expect(totals.marketPrice).toBe(21000);
+    expect(totals.priceWithPremium).toBeCloseTo(21687.75);
+    expect(totals.marketTotalWithFee).toBe(21020);
+    expect(totals.premiumTotalWithFee).toBeCloseTo(21707.75);
+    expect(totals.premiumDiff).toBeCloseTo(687.75);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -4,10 +4,13 @@
   "description": "A small tool for friends to practice crypto-to-fiat conversion, helping learn value and pricing through simple quote simulations.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"No tests\""
+    "test": "jest"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "type": "commonjs"
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.7.0"
+  }
 }


### PR DESCRIPTION
## Summary
- extract pricing and total calculations into `calc.js`
- add unit tests for market price, premium, and totals
- configure Jest test runner

## Testing
- `npm test` *(fails: jest: not found, package not installed due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68baa82cc9a8832b8e03db19441b65a5