### PR TITLE
Restructure input fields into grid and flex rows

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,31 +107,38 @@
             <button className="border px-2 py-1" onClick={() => setLang(lang === 'en' ? 'zh' : 'en')}>{t.toggle}</button>
           </div>
 
-          <div className="flex flex-wrap gap-4">
-            <label className="flex flex-col flex-1 min-w-[140px]">{t.ethUsd}
-              <input type="number" min="0" className="border p-1" value={ethUsd} onChange={e => setEthUsd(Math.max(0, parseFloat(e.target.value) || 0))} onFocus={e => e.target.select()} />
-              <span className="text-xs text-gray-500">{lang === 'en' ? 'DEX/CEX market' : '与DEX/CEX行情一致'}</span>
-            </label>
-            <label className="flex flex-col flex-1 min-w-[140px]">{t.usdCny}
-              <input type="number" min="0" step="0.00001" className="border p-1" value={usdCny.toFixed(5)} onChange={e => setUsdCny(Math.max(0, parseFloat(e.target.value) || 0))} onFocus={e => e.target.select()} />
-              <span className="text-xs text-gray-500">{lang === 'en' ? '1 USD equals CNY' : '1美元兑换多少人民币'}</span>
-            </label>
-            <label className="flex flex-col flex-1 min-w-[140px]">{t.fee}
-              <input type="number" min="0" className="border p-1" value={fee} onChange={e => setFee(Math.max(0, parseFloat(e.target.value) || 0))} onFocus={e => e.target.select()} />
-              <span className="text-xs text-gray-500">{lang === 'en' ? 'Handling fee in CNY' : '以人民币计的手续费'}</span>
-            </label>
+          <div className="grid grid-cols-2 gap-4">
+            <div className="space-y-4">
+              <label className="flex flex-col">{t.ethUsd}
+                <input type="number" min="0" className="border p-1" value={ethUsd} onChange={e => setEthUsd(Math.max(0, parseFloat(e.target.value) || 0))} onFocus={e => e.target.select()} />
+                <span className="text-xs text-gray-500">{lang === 'en' ? 'DEX/CEX market' : '与DEX/CEX行情一致'}</span>
+              </label>
+              <label className="flex flex-col">{t.ethAmount}
+                <input type="number" min="0" className="border p-1" value={ethAmount} onChange={handleEthChange} placeholder="1" onFocus={e => e.target.select()} />
+              </label>
+            </div>
+            <div className="space-y-4">
+              <label className="flex flex-col">{t.usdCny}
+                <input type="number" min="0" step="0.00001" className="border p-1" value={usdCny.toFixed(5)} onChange={e => setUsdCny(Math.max(0, parseFloat(e.target.value) || 0))} onFocus={e => e.target.select()} />
+                <span className="text-xs text-gray-500">{lang === 'en' ? '1 USD equals CNY' : '1美元兑换多少人民币'}</span>
+              </label>
+              <label className="flex flex-col">{t.cnyAmount}
+                <input type="number" min="0" className="border p-1" value={cnyAmount} onChange={handleCnyChange} placeholder="auto" onFocus={e => e.target.select()} />
+              </label>
+            </div>
+          </div>
+
+          <div className="flex gap-4">
             <label className="flex flex-col flex-1 min-w-[140px]">{t.premium}
               <div className="flex border p-1 items-center">
-                <input type="number" min="0" max="100" step="0.001" className="flex-1 outline-none" value={premium} onChange={e => setPremium(parseFloat(e.target.value) || 0)} onFocus={e => e.target.select()} />
+                <input type="number" min="0" max="100" step="0.001" className="flex-1 outline-none" value={premium} onChange={e=> setPremium(parseFloat(e.target.value) || 0)} onFocus={e => e.target.select()} />
                 <span className="ml-1">%</span>
               </div>
               <span className="text-xs text-gray-500">{lang === 'en' ? '0-100%' : '范围0-100%'}</span>
             </label>
-            <label className="flex flex-col flex-1 min-w-[140px]">{t.ethAmount}
-              <input type="number" min="0" className="border p-1" value={ethAmount} onChange={handleEthChange} placeholder="1" onFocus={e => e.target.select()} />
-            </label>
-            <label className="flex flex-col flex-1 min-w-[140px]">{t.cnyAmount}
-              <input type="number" min="0" className="border p-1" value={cnyAmount} onChange={handleCnyChange} placeholder="auto" onFocus={e => e.target.select()} />
+            <label className="flex flex-col flex-1 min-w-[140px]">{t.fee}
+              <input type="number" min="0" className="border p-1" value={fee} onChange={e => setFee(Math.max(0, parseFloat(e.target.value) || 0))} onFocus={e => e.target.select()} />
+              <span className="text-xs text-gray-500">{lang === 'en' ? 'Handling fee in CNY' : '以人民币计的手续费'}</span>
             </label>
           </div>
 


### PR DESCRIPTION
## Summary
- Reorganize input UI: price and amounts moved into two-column grid
- Separate premium and fee inputs into flex row

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68baac5ed968832ba7febb59fe57f7cd