### PR TITLE
refactor: simplify ETH total calculations

### DIFF
--- a/calc.js
+++ b/calc.js
@@ -6,13 +6,12 @@ function calculatePriceWithPremium(marketPrice, premiumPercent) {
   return marketPrice * (1 + premiumPercent / 100);
 }
 
-function calculateTotals({ ethUsd, usdCny, premiumPercent, fee, ethAmount = 0, cnyAmount = '' }) {
+function calculateTotals({ ethUsd, usdCny, premiumPercent, fee, ethAmount = 0 }) {
   const marketPrice = calculateMarketPrice(ethUsd, usdCny);
   const priceWithPremium = calculatePriceWithPremium(marketPrice, premiumPercent);
-  const ethTotal = cnyAmount !== '' ? (parseFloat(cnyAmount) || 0) / marketPrice : (parseFloat(ethAmount) || 0);
 
-  const marketTotal = ethTotal * marketPrice;
-  const premiumTotal = ethTotal * priceWithPremium;
+  const marketTotal = (parseFloat(ethAmount) || 0) * marketPrice;
+  const premiumTotal = (parseFloat(ethAmount) || 0) * priceWithPremium;
 
   return {
     marketPrice,

--- a/calc.test.js
+++ b/calc.test.js
@@ -11,13 +11,7 @@ describe('calculation functions', () => {
   });
 
   test('calculateTotals returns totals with fee and premium', () => {
-    const totals = calculateTotals({
-      ethUsd: 3000,
-      usdCny: 7,
-      premiumPercent: 3.275,
-      fee: 20,
-      ethAmount: 1,
-    });
+    const totals = calculateTotals({ ethUsd: 3000, usdCny: 7, premiumPercent: 3.275, fee: 20, ethAmount: 1 });
 
     expect(totals.marketPrice).toBe(21000);
     expect(totals.priceWithPremium).toBeCloseTo(21687.75);


### PR DESCRIPTION
## Summary
- remove `cnyAmount` parameter from `calculateTotals` and compute totals using only `ethAmount`
- adjust unit test to call `calculateTotals` with `ethAmount` only

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/jest)*

------
https://chatgpt.com/codex/tasks/task_e_68baad8e77dc832b8a46e2e431dd42c4