### PR TITLE
Handle invalid inputs in price calculations

### DIFF
--- a/calc.js
+++ b/calc.js
@@ -1,12 +1,42 @@
 function calculateMarketPrice(ethUsd, usdCny) {
+  if (
+    isNaN(ethUsd) ||
+    isNaN(usdCny) ||
+    ethUsd < 0 ||
+    usdCny < 0
+  ) {
+    return 0;
+  }
   return ethUsd * usdCny;
 }
 
 function calculatePriceWithPremium(marketPrice, premiumPercent) {
+  if (
+    isNaN(marketPrice) ||
+    isNaN(premiumPercent) ||
+    marketPrice < 0 ||
+    premiumPercent < 0
+  ) {
+    return 0;
+  }
   return marketPrice * (1 + premiumPercent / 100);
 }
 
 function calculateTotals({ ethUsd, usdCny, premiumPercent, fee, ethAmount = 0 }) {
+  if (
+    [ethUsd, usdCny, premiumPercent, fee, ethAmount].some(
+      (v) => isNaN(v) || v < 0
+    )
+  ) {
+    return {
+      marketPrice: 0,
+      priceWithPremium: 0,
+      marketTotalWithFee: 0,
+      premiumTotalWithFee: 0,
+      premiumDiff: 0,
+    };
+  }
+
   const marketPrice = calculateMarketPrice(ethUsd, usdCny);
   const priceWithPremium = calculatePriceWithPremium(marketPrice, premiumPercent);
 

--- a/calc.test.js
+++ b/calc.test.js
@@ -5,9 +5,23 @@ describe('calculation functions', () => {
     expect(calculateMarketPrice(3000, 7)).toBe(21000);
   });
 
+  test('calculateMarketPrice returns 0 for invalid inputs', () => {
+    expect(calculateMarketPrice(NaN, 7)).toBe(0);
+    expect(calculateMarketPrice(3000, NaN)).toBe(0);
+    expect(calculateMarketPrice(-3000, 7)).toBe(0);
+    expect(calculateMarketPrice(3000, -7)).toBe(0);
+  });
+
   test('calculatePriceWithPremium applies premium percentage', () => {
     const marketPrice = 21000;
     expect(calculatePriceWithPremium(marketPrice, 3.275)).toBeCloseTo(21687.75);
+  });
+
+  test('calculatePriceWithPremium returns 0 for invalid inputs', () => {
+    expect(calculatePriceWithPremium(NaN, 3)).toBe(0);
+    expect(calculatePriceWithPremium(21000, NaN)).toBe(0);
+    expect(calculatePriceWithPremium(-21000, 3)).toBe(0);
+    expect(calculatePriceWithPremium(21000, -3)).toBe(0);
   });
 
   test('calculateTotals returns totals with fee and premium', () => {
@@ -18,5 +32,25 @@ describe('calculation functions', () => {
     expect(totals.marketTotalWithFee).toBe(21020);
     expect(totals.premiumTotalWithFee).toBeCloseTo(21707.75);
     expect(totals.premiumDiff).toBeCloseTo(687.75);
+  });
+
+  test('calculateTotals returns default values for invalid inputs', () => {
+    const negativeTotals = calculateTotals({ ethUsd: -3000, usdCny: 7, premiumPercent: 3, fee: 20, ethAmount: 1 });
+    expect(negativeTotals).toEqual({
+      marketPrice: 0,
+      priceWithPremium: 0,
+      marketTotalWithFee: 0,
+      premiumTotalWithFee: 0,
+      premiumDiff: 0,
+    });
+
+    const nanTotals = calculateTotals({ ethUsd: 3000, usdCny: 7, premiumPercent: 3, fee: NaN, ethAmount: 1 });
+    expect(nanTotals).toEqual({
+      marketPrice: 0,
+      priceWithPremium: 0,
+      marketTotalWithFee: 0,
+      premiumTotalWithFee: 0,
+      premiumDiff: 0,
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Validate inputs for market price, premium price, and totals calculations
- Return default values when encountering NaN or negative inputs
- Add tests covering invalid input scenarios

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bbe1f1f8ec832bb243a009cda627bc